### PR TITLE
Remove separateStructure

### DIFF
--- a/src/descriptors/template.json
+++ b/src/descriptors/template.json
@@ -37,10 +37,6 @@
           "name": "typeMetadata",
           "isAttr": true,
           "type": "Boolean"
-        },{
-          "name": "separateStructure",
-          "isAttr": true,
-          "type": "Boolean"
         },
         {
           "name": "typeAutomatic",

--- a/src/language/de_DE.js
+++ b/src/language/de_DE.js
@@ -14,8 +14,6 @@ de_DE = {
     "closed": "Abgeschlossen",
     "metadata": "Metadaten",
     "metadataDescription": "Metadaten in der Aufgabe bearbeiten?",
-    "separateStructure": "Erweiterter Strukturbaum",
-    "separateStructureDescription": " ",
     "typeImagesRead": "Bilder lesen",
     "typeImagesReadDescription": " ",
     "typeImagesWrite": "Bilder schreiben",

--- a/src/language/en_EN.js
+++ b/src/language/en_EN.js
@@ -14,8 +14,6 @@ en_EN = {
     "closed": "Closed",
     "metadata": "Metadata",
     "metadataDescription": "Is it task metadata type?",
-    "separateStructure": "Extended Structure Tree",
-    "separateStructureDescription": " ",
     "typeImagesRead": "Read images",
     "typeImagesReadDescription": " ",
     "typeImagesWrite": "Write Images",

--- a/src/provider/template/parts/TaskProperties.js
+++ b/src/provider/template/parts/TaskProperties.js
@@ -36,13 +36,6 @@ export default function (group, element, translate) {
         }));
 
         group.entries.push(entryFactory.checkbox(translate, {
-            id: 'separateStructure',
-            description: getLocalizedStringForKey('separateStructureDescription'),
-            label: getLocalizedStringForKey('separateStructure'),
-            modelProperty: 'separateStructure'
-        }));
-
-        group.entries.push(entryFactory.checkbox(translate, {
             id: 'typeImagesRead',
             description: getLocalizedStringForKey('typeImagesReadDescription'),
             label: getLocalizedStringForKey('typeImagesRead'),

--- a/styles/modeler_custom.less
+++ b/styles/modeler_custom.less
@@ -82,10 +82,6 @@
     clip: rect(1px, 1px, 1px, 1px);
 }
 
-div[data-entry=separateStructure] {
-  padding-left: 15px;
-}
-
 .bpp-textfield input, .bpp-properties-panel [contenteditable] {
   padding-right: 20px !important;
   width: calc(100% - 28px) !important;


### PR DESCRIPTION
separateStructure is now displayed at the top of the form.
The WorkflowEditor is producing an Error, because separateStructure is not an attribute of Task anymore.
see https://github.com/kitodo/kitodo-production/pull/4398